### PR TITLE
Modify StaticPages views with meaningful content

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,7 @@
+class StaticPagesController < ApplicationController
+  def home
+  end
+
+  def help
+  end
+end

--- a/app/helpers/static_pages_helper.rb
+++ b/app/helpers/static_pages_helper.rb
@@ -1,0 +1,2 @@
+module StaticPagesHelper
+end

--- a/app/views/static_pages/help.html.erb
+++ b/app/views/static_pages/help.html.erb
@@ -1,0 +1,2 @@
+<h1>StaticPages#help</h1>
+<p>Find me in app/views/static_pages/help.html.erb</p>

--- a/app/views/static_pages/help.html.erb
+++ b/app/views/static_pages/help.html.erb
@@ -1,2 +1,8 @@
-<h1>StaticPages#help</h1>
-<p>Find me in app/views/static_pages/help.html.erb</p>
+<h1>Help</h1>
+<p>
+  Get help on the Ruby on Rails Tutorial at the
+  <a href="https://railstutorial.jp/help">Rails Tutorial Help page</a>.
+  To get help on this sample app, see the
+  <a href="https://railstutorial.jp/#ebook"><em>Ruby on Rails Tutorial</em>
+  book</a>.
+</p>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,0 +1,2 @@
+<h1>StaticPages#home</h1>
+<p>Find me in app/views/static_pages/home.html.erb</p>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,2 +1,6 @@
-<h1>StaticPages#home</h1>
-<p>Find me in app/views/static_pages/home.html.erb</p>
+<h1>Demo App</h1>
+<p>
+  This is the home page for the
+  <a href="https://railstutorial.jp/">Ruby on Rails Tutorial</a>
+  sample application.
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
+  get 'static_pages/home'
+  get 'static_pages/help'
   root "application#hello"
 end

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class StaticPagesControllerTest < ActionDispatch::IntegrationTest
+  test "should get home" do
+    get static_pages_home_url
+    assert_response :success
+  end
+
+  test "should get help" do
+    get static_pages_help_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
概要
StaticPagesコントローラに対応するビュー (home と help) を修正し、より意味のあるコンテンツを表示するように変更した。
Rails Tutorialに沿った内容を基に、HomeページとHelpページに静的なHTMLを追加した。

変更内容
Homeページ (app/views/static_pages/home.html.erb)

タイトルとして "Sample App" を追加。
Ruby on Rails Tutorial のリンクを含む簡単な説明文を追加。
Helpページ (app/views/static_pages/help.html.erb)

タイトルとして "Help" を追加。
Rails Tutorialのヘルプページおよびサンプルアプリのサポート情報を提供するリンクを追加。

背景と目的
初期のプレースホルダ内容を実際のアプリケーションに即した静的コンテンツに置き換えることで、アプリの意図や目標をわかりやすく伝えること。
Railsでのビューとコントローラの連携をより深く理解するために実施した変更。